### PR TITLE
Update/es6 transform 6to5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Options:
 ```
 -h, --help            output usage information
 -V, --version         output the version number
--e, --es6             Transform es6 code to es5 using traceur
+-e, --es6             Transform es6 code to es5 using 6to5
 -d, --debug           Include source files
 -f, --fullpaths       Expand Browserify ids to full paths
 -m, --minify          Minify the resulting bundle

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ process.on('uncaughtException', function(err) {
 
 program
   .version(version)
-  .option('-e, --es6', 'Transform es6 code to es5 using traceur')
+  .option('-e, --es6', 'Transform es6 code to es5 using 6to5')
   .option('-d, --debug', 'Include source files')
   .option('-f, --fullpaths', 'Expand Browserify ids to full paths')
   .option('-m, --minify', 'Minify the resulting bundle')

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 var fs         = require('fs')
   , browserify = require('browserify')
-  , es6ify     = require('es6ify')
+  , to5ify    = require('6to5ify')
   , uglifyify  = require('uglifyify')
   , program    = require('commander')
   , brfs       = require('brfs')
@@ -84,7 +84,7 @@ function run(source, dest) {
     fullPaths: !!program.fullpaths
   })
 
-  if (program.es6) bundler = bundler.transform(es6ify)
+  if (program.es6) bundler = bundler.transform(to5ify)
 
   if (program.brfs) bundler = bundler.transform(brfs)
 

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "buildbro": "index.js"
   },
   "dependencies": {
+    "6to5ify": "^3.1.2",
     "brfs": "^1.2.0",
     "browserify": "^6.1.0",
     "chalk": "^0.5.1",
     "commander": "^2.3.0",
-    "es6ify": "^1.4.0",
     "http-server": "^0.7.2",
     "uglifyify": "^2.5.0",
     "watchify": "^2.0.0"


### PR DESCRIPTION
es6 transpilation is somewhat limited using traceur, and it requires users to include the traceur-runtime script as well.

Moving to 6to5 for improved es6 feature support and no external scripts required.